### PR TITLE
scripts/pyzor: read stdin as binary in _get_input_msg().

### DIFF
--- a/scripts/pyzor
+++ b/scripts/pyzor
@@ -171,7 +171,10 @@ def _get_input_digests(dummy):
 
 
 def _get_input_msg(digester):
-    msg = email.message_from_file(sys.stdin)
+    # Read and process stdin as bytes because we don't know its
+    # encoding. Python-3.x will try to guess -- and can sometimes
+    # guess wrong -- leading to decoding errors in read().
+    msg = email.message_from_bytes(get_binary_stdin().read())
     digested = digester(msg).value
     yield digested
 


### PR DESCRIPTION
Fix for issue #64, after running it overnight on our MX.