### PR TITLE
Python3 Update 

### DIFF
--- a/pyzor/client.py
+++ b/pyzor/client.py
@@ -89,32 +89,44 @@ class Client(object):
     def ping(self, address=("public.pyzor.org", 24441)):
         msg = pyzor.message.PingRequest()
         sock = self.send(msg, address)
-        return self.read_response(sock, msg.get_thread())
+        response = self.read_response(sock, msg.get_thread())
+        sock.close()
+        return response
 
     def pong(self, digest, address=("public.pyzor.org", 24441)):
         msg = pyzor.message.PongRequest(digest)
         sock = self.send(msg, address)
-        return self.read_response(sock, msg.get_thread())
+        response = self.read_response(sock, msg.get_thread())
+        sock.close()
+        return response
 
     def info(self, digest, address=("public.pyzor.org", 24441)):
         msg = pyzor.message.InfoRequest(digest)
         sock = self.send(msg, address)
-        return self.read_response(sock, msg.get_thread())
+        response = self.read_response(sock, msg.get_thread())
+        sock.close()
+        return response
 
     def report(self, digest, address=("public.pyzor.org", 24441)):
         msg = pyzor.message.ReportRequest(digest, self.spec)
         sock = self.send(msg, address)
-        return self.read_response(sock, msg.get_thread())
+        response = self.read_response(sock, msg.get_thread())
+        sock.close()
+        return response
 
     def whitelist(self, digest, address=("public.pyzor.org", 24441)):
         msg = pyzor.message.WhitelistRequest(digest, self.spec)
         sock = self.send(msg, address)
-        return self.read_response(sock, msg.get_thread())
+        response = self.read_response(sock, msg.get_thread())
+        sock.close()
+        return response
 
     def check(self, digest, address=("public.pyzor.org", 24441)):
         msg = pyzor.message.CheckRequest(digest)
         sock = self.send(msg, address)
-        return self.read_response(sock, msg.get_thread())
+        response = self.read_response(sock, msg.get_thread())
+        sock.close()
+        return response
 
     def _mock_check(self, digests, address=None):
         msg = (u"Code: %s\nDiag: OK\nPV: %s\nThread: 1024\nCount: 0\n"
@@ -202,10 +214,14 @@ class BatchClient(Client):
         self.flush()
 
     def report(self, digest, address=("public.pyzor.org", 24441)):
-        self._add_digest(digest, address, self.r_requests)
+        socket = self._add_digest(digest, address, self.r_requests)
+        if socket:
+            socket.close()
 
     def whitelist(self, digest, address=("public.pyzor.org", 24441)):
-        self._add_digest(digest, address, self.w_requests)
+        socket = self._add_digest(digest, address, self.w_requests)
+        if socket:
+            socket.close()
 
     def _add_digest(self, digest, address, requests):
         address = (address[0], int(address[1]))
@@ -229,12 +245,14 @@ class BatchClient(Client):
         """Force send any remaining reports."""
         for address, msg in self.r_requests.items():
             try:
-                self.send(msg, address)
+                ret = self.send(msg, address)
+                ret.close()
             except:
                 continue
         for address, msg in self.w_requests.items():
             try:
-                self.send(msg, address)
+                ret = self.send(msg, address)
+                ret.close()
             except:
                 continue
 

--- a/pyzor/config.py
+++ b/pyzor/config.py
@@ -63,12 +63,12 @@ def load_access_file(access_fn, accounts):
             operations, users, allowed = [part.lower().strip()
                                           for part in line.split(":")]
         except ValueError:
-            log.warn("Invalid ACL line: %r", line)
+            log.warning("Invalid ACL line: %r", line)
             continue
         try:
             allowed = {"allow": True, "deny": False}[allowed]
         except KeyError:
-            log.warn("Invalid ACL line: %r", line)
+            log.warning("Invalid ACL line: %r", line)
             continue
         if operations == "all":
             operations = ("check", "report", "ping", "pong", "info",
@@ -118,7 +118,7 @@ def load_passwd_file(passwd_fn):
         try:
             user, key = line.split(":")
         except ValueError:
-            log.warn("Invalid accounts line: %r", line)
+            log.warning("Invalid accounts line: %r", line)
             continue
         user = user.strip()
         key = key.strip()
@@ -145,29 +145,29 @@ def load_accounts(filepath):
                 host, port, username, key = [x.strip()
                                              for x in line.split(":")]
             except ValueError:
-                log.warn("account file: invalid line %d: wrong number of "
+                log.warning("account file: invalid line %d: wrong number of "
                          "parts", lineno)
                 continue
             try:
                 port = int(port)
             except ValueError as ex:
-                log.warn("account file: invalid line %d: %s", lineno, ex)
+                log.warning("account file: invalid line %d: %s", lineno, ex)
                 continue
             address = (host, port)
             try:
                 salt, key = pyzor.account.key_from_hexstr(key)
             except ValueError as ex:
-                log.warn("account file: invalid line %d: %s", lineno, ex)
+                log.warning("account file: invalid line %d: %s", lineno, ex)
                 continue
             if not salt and not key:
-                log.warn("account file: invalid line %d: keystuff can't be "
+                log.warning("account file: invalid line %d: keystuff can't be "
                          "all None's", lineno)
                 continue
             accounts[address] = pyzor.account.Account(username, salt, key)
         accountsf.close()
 
     else:
-        log.warn("No accounts are setup.  All commands will be executed by "
+        log.warning("No accounts are setup.  All commands will be executed by "
                  "the anonymous user.")
     return accounts
 

--- a/pyzor/hacks/py3.py
+++ b/pyzor/hacks/py3.py
@@ -4,7 +4,7 @@ import sys
 
 
 def reload(module):
-    """Reload the modeule.
+    """Reload the module.
 
     This is handled differently according to the
     python version. This even varies across Python3

--- a/pyzor/hacks/py3.py
+++ b/pyzor/hacks/py3.py
@@ -3,7 +3,7 @@
 import sys
 
 
-def reload(module):
+def _reload(module):
     """Reload the module.
 
     This is handled differently according to the

--- a/pyzor/server.py
+++ b/pyzor/server.py
@@ -146,10 +146,9 @@ class PreForkServer(Server):
             if not pid:
                 # Create the database in the child process, to prevent issues
                 self.database = database()
-                self.is_worker = True
-                self.log.info("Worker process started.")
+                self.log.debug("Worker process started.")
                 Server.serve_forever(self, poll_interval=poll_interval)
-                self.log.info("Clean-up done for worker process.")
+                self.log.debug("Clean-up done for worker process.")
                 os._exit(0)
             else:
                 pids.append(pid)

--- a/scripts/pyzord
+++ b/scripts/pyzord
@@ -92,7 +92,7 @@ def initialize_forwarding(client_config_dir, debug):
     }
     config = ConfigParser.ConfigParser()
     config.add_section("client")
-    for key, value in forward_defaults.iteritems():
+    for key, value in forward_defaults.items():
         config.set("client", key, value)
 
     config.read(os.path.join(client_config_dir, "config"))
@@ -127,6 +127,7 @@ def load_configuration():
         homedir = os.path.join(userhome, '.pyzor')
     else:
         homedir = os.path.join("/etc", "pyzor")
+
 
     # Configuration defaults.  The configuration file overrides these, and
     # then the command-line options override those.

--- a/scripts/pyzord
+++ b/scripts/pyzord
@@ -347,7 +347,7 @@ def main():
         # Enssure that all modules are reloaded so they benefit from
         # the gevent library.
         for module in (os, sys, pyzor, pyzor.server, pyzor.engines):
-            pyzor.hacks.py3.reload(module)
+            pyzor.hacks.py3._reload(module)
 
     if options.detach:
         detach(stdout=options.detach, pidfile=pidfile_fn)

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -30,6 +30,7 @@ else
 
     if [ "$1" != "prepare" ]
     then
-        py.test tests/unit/ --cov pyzor --cov-report term-missing        
+        py.test tests/unit/ --cov pyzor --cov-report term-missing
+        py.test tests/functional/
     fi
 fi

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -17,7 +17,7 @@ else
         sudo apt-get install -y python-dev
     fi
 
-    mysql --version | grep -qi maria && sudo apt-get install -y libmariadbclient-dev
+    mysql --version | grep -qi maria && sudo apt-get install -y libmariadb-dev-compat libmariadb-dev
     mysql --version | grep -qi maria || sudo apt-get install -y libmysqlclient-dev
 
     sudo apt-get install -y build-essential
@@ -30,7 +30,10 @@ else
 
     if [ "$1" != "prepare" ]
     then
-        py.test tests/unit/ --cov pyzor --cov-report term-missing
-        py.test tests/functional/
+        # py.test tests/unit/ --cov pyzor --cov-report term-missing
+        # py.test tests/functional/test_engines/test_mysql.py::PreForkMySQLdbPyzorTest --cov pyzor --cov-report term-missing
+        
+        py.test tests/functional/test_engines/test_redis.py::PreForkRedisPyzorTest --cov pyzor --cov-report term-missing
+    # PreForkRedisPyzorTest
     fi
 fi

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -22,18 +22,14 @@ else
 
     sudo apt-get install -y build-essential
 
-    pip install pytest pytest-cov python-coveralls
-    pip install -r requirements.txt
-    python setup.py install
+    python -m pip install pytest pytest-cov python-coveralls
+    python -m pip install -r requirements.txt
+    python -m pip install .
     mysql -e 'create database if not exists pyzor_test'
 
 
     if [ "$1" != "prepare" ]
     then
-        # py.test tests/unit/ --cov pyzor --cov-report term-missing
-        # py.test tests/functional/test_engines/test_mysql.py::PreForkMySQLdbPyzorTest --cov pyzor --cov-report term-missing
-        
-        py.test tests/functional/test_engines/test_redis.py::PreForkRedisPyzorTest --cov pyzor --cov-report term-missing
-    # PreForkRedisPyzorTest
+        py.test tests/unit/ --cov pyzor --cov-report term-missing        
     fi
 fi

--- a/tests/functional/test_account.py
+++ b/tests/functional/test_account.py
@@ -3,7 +3,7 @@ import unittest
 from tests.util import *
 
 class AccountPyzorTest(PyzorTestBase):
-    
+
     # test bob which has access to everything
     def test_ping(self):
         self.check_pyzor("ping", "bob", code=200, exit_code=0)
@@ -132,7 +132,6 @@ def suite():
     test_suite.addTest(unittest.makeSuite(AccountPyzorTest))
     test_suite.addTest(unittest.makeSuite(AnonymousPyzorTest))
     return test_suite
-        
+
 if __name__ == '__main__':
     unittest.main()
-            

--- a/tests/functional/test_engines/__init__.py
+++ b/tests/functional/test_engines/__init__.py
@@ -13,9 +13,9 @@ import unittest
 
 def suite():
     """Gather all the tests from this package in a test suite."""
-    import test_gdbm
-    import test_mysql
-    import test_redis
+    from . import test_gdbm
+    from . import test_mysql
+    from . import test_redis
 
     test_suite = unittest.TestSuite()
 

--- a/tests/functional/test_forwarder.py
+++ b/tests/functional/test_forwarder.py
@@ -22,7 +22,7 @@ class ForwardSetup(object):
         except OSError:
             pass
 
-@unittest.skip("This fails randomly on PyPy.")
+
 class ForwarderTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -115,7 +115,14 @@ class LoadAccountTest(unittest.TestCase):
             pyzor.account.__builtins__["open"] = self.real_open
 
     def test_load_accounts_nothing(self):
-        result = pyzor.config.load_accounts("foobar")
+        try:
+            with self.assertLogs("pyzor", level='WARNING') as logs:
+                result = pyzor.config.load_accounts("foobar")
+                self.assertEqual(["WARNING:pyzor:No accounts are setup.  All commands will be executed by the anonymous user."], logs.output)
+        except AttributeError as e:
+            # Python 2 backwards compatibility.
+            self.assertEqual(e.message, "'LoadAccountTest' object has no attribute 'assertLogs'")
+            result = pyzor.config.load_accounts("foobar")
         self.assertEqual(result, {})
 
     def test_load_accounts(self):
@@ -136,7 +143,15 @@ class LoadAccountTest(unittest.TestCase):
         """Test loading the account file"""
         self.mock_file.write(u"public.pyzor.org : 24441 ; test : 123abc,cba321\n"
                              u"public2.pyzor.org : 24441 : test2 : 123abc,cba321")
-        result = pyzor.config.load_accounts(self.filepath)
+        try:
+            with self.assertLogs("pyzor", level='WARNING') as logs:
+                result = pyzor.config.load_accounts(self.filepath)
+                self.assertEqual(["WARNING:pyzor:account file: invalid line 0: wrong number of parts"], logs.output)
+        except AttributeError as e:
+            # Python 2 backwards compatibility.
+            self.assertEqual(e.message, "'LoadAccountTest' object has no attribute 'assertLogs'")
+            result = pyzor.config.load_accounts(self.filepath)
+
         self.assertNotIn(("public.pyzor.org", 24441), result)
         self.assertEqual(len(result), 1)
         self.assertIn(("public2.pyzor.org", 24441), result)
@@ -148,7 +163,15 @@ class LoadAccountTest(unittest.TestCase):
         """Test loading the account file"""
         self.mock_file.write(u"public.pyzor.org : a4441 : test : 123abc,cba321\n"
                              u"public2.pyzor.org : 24441 : test2 : 123abc,cba321")
-        result = pyzor.config.load_accounts(self.filepath)
+        try:
+            with self.assertLogs("pyzor", level='WARNING') as logs:
+                result = pyzor.config.load_accounts(self.filepath)
+                self.assertEqual(["WARNING:pyzor:account file: invalid line 0: invalid literal for int() with base 10: 'a4441'"], logs.output)
+        except AttributeError as e:
+            # Python 2 backwards compatibility.
+            self.assertEqual(e.message, "'LoadAccountTest' object has no attribute 'assertLogs'")
+            result = pyzor.config.load_accounts(self.filepath)
+
         self.assertNotIn(("public.pyzor.org", 24441), result)
         self.assertEqual(len(result), 1)
         self.assertIn(("public2.pyzor.org", 24441), result)
@@ -160,7 +183,14 @@ class LoadAccountTest(unittest.TestCase):
         """Test loading the account file"""
         self.mock_file.write(u"public.pyzor.org : 24441 : test : ,\n"
                              u"public2.pyzor.org : 24441 : test2 : 123abc,cba321")
-        result = pyzor.config.load_accounts(self.filepath)
+        try:
+            with self.assertLogs("pyzor", level='WARNING') as logs:
+                result = pyzor.config.load_accounts(self.filepath)
+                self.assertEqual(["WARNING:pyzor:account file: invalid line 0: keystuff can't be all None's"], logs.output)
+        except AttributeError as e:
+            # Python 2 backwards compatibility.
+            self.assertEqual(e.message, "'LoadAccountTest' object has no attribute 'assertLogs'")
+            result = pyzor.config.load_accounts(self.filepath)
         self.assertNotIn(("public.pyzor.org", 24441), result)
         self.assertEqual(len(result), 1)
         self.assertIn(("public2.pyzor.org", 24441), result)
@@ -172,7 +202,16 @@ class LoadAccountTest(unittest.TestCase):
         """Test loading the account file"""
         self.mock_file.write(u"public.pyzor.org : 24441 : test : 123abccba321\n"
                              u"public2.pyzor.org : 24441 : test2 : 123abc,cba321")
-        result = pyzor.config.load_accounts(self.filepath)
+        try:
+            with self.assertLogs("pyzor", level='WARNING') as logs:
+                result = pyzor.config.load_accounts(self.filepath)
+                self.assertEqual(["WARNING:pyzor:account file: invalid line 0: Invalid number of parts for key; perhaps you forgot the comma at the beginning for the salt divider?"],
+logs.output)
+        except AttributeError as e:
+            # Python 2 backwards compatibility.
+            self.assertEqual(e.message, "'LoadAccountTest' object has no attribute 'assertLogs'")
+            result = pyzor.config.load_accounts(self.filepath)
+
         self.assertNotIn(("public.pyzor.org", 24441), result)
         self.assertEqual(len(result), 1)
         self.assertIn(("public2.pyzor.org", 24441), result)

--- a/tests/unit/test_engines/__init__.py
+++ b/tests/unit/test_engines/__init__.py
@@ -9,10 +9,10 @@ import unittest
 
 def suite():
     """Gather all the tests from this package in a test suite."""
-    import test_gdbm
-    import test_mysql
-    import test_redis
-    import test_redis_v0
+    from . import test_gdbm
+    from . import test_mysql
+    from . import test_redis
+    from . import test_redis_v0
 
     test_suite = unittest.TestSuite()
 
@@ -24,4 +24,3 @@ def suite():
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')
-

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -246,7 +246,6 @@ class PyzorTestBase(unittest.TestCase):
 
     def check_digest(self, digest, address, counts=(0, 0)):
         result = self.client.check(digest, address)
-
         self.assertEqual((int(result["Count"]), int(result["WL-Count"])),
                           counts)
         return result


### PR DESCRIPTION
This PR deals with migrating the Pyzor code to python3. 

Changelist:
-> ensure pyzord server always uses a non blocking socket (this way the forking server works asynchronously/will shut down gracefully when catching SIGTERM signal).
-> close sockets in client. 
-> miscellaneous fixes from py2 to py3 (methods like dict.items or loging.warning).

-> fix tests